### PR TITLE
Change Nameservers to generic options.

### DIFF
--- a/ip/ip.go
+++ b/ip/ip.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	PrimaryNameserver  = "ns-cloud-c1.googledomains.com"
-	FallbackNameserver = "ns-cloud-c2.googledomains.com"
+	PrimaryNameserver  = "dns.google"
+	FallbackNameserver = "one.one.one.one"
 )
 
 type Address struct {


### PR DESCRIPTION
Solving GH-1 where domain specific Nameservers were being used. This commit adds the Google and Cloudflare DNS as primary and fallback DNS servers respectively.